### PR TITLE
Align curve name with the spec when parsing public key data

### DIFF
--- a/prism-core/src/did/operation.rs
+++ b/prism-core/src/did/operation.rs
@@ -405,8 +405,8 @@ impl SupportedPublicKey {
 
         match curve_name {
             "secp256k1" => Ok(Self::Secp256k1(Self::convert_secp256k1(key_data)?)),
-            "ed25519" => Ok(Self::Ed25519(Self::convert_ed25519(key_data)?)),
-            "x25519" => Ok(Self::X25519(Self::convert_x25519(key_data)?)),
+            "Ed25519" => Ok(Self::Ed25519(Self::convert_ed25519(key_data)?)),
+            "X25519" => Ok(Self::X25519(Self::convert_x25519(key_data)?)),
             c => Err(CryptoError::UnsupportedCurve { curve: c.to_string() }),
         }
     }


### PR DESCRIPTION
Spotted some error on preprod like this did `did:prism:9ecca3f8981ab8baa7aa0d8a9a98d5f648615a1ef668d3037ab84ad6d5dd5d0a`

```
Cardano Block Time: 2024-06-06T10:28:12Z
Slot: 61986492
Block: 2327726
Atala Block Sequence Number: 0
Operation Sequence Number: 0

SignedAtalaOperation { signed_with: "master0", signature: [48, 68, 2, 32, 47, 67, 109, 202, 121, 5, 238, 173, 75, 127, 52, 247, 42, 193, 81, 197, 132, 29, 246, 2, 162, 177, 51, 231, 69, 72, 65, 55, 46, 170, 215, 168, 2, 32, 57, 194, 127, 142, 227, 8, 29, 241, 166, 233, 118, 88, 84, 76, 177, 3, 182, 78, 247, 126, 178, 48, 149, 236, 169, 27, 69, 100, 19, 186, 162, 54], operation: Some(AtalaOperation { operation: Some(CreateDid(CreateDidOperation { did_data: Some(DidCreationData { public_keys: [PublicKey { id: "my-key-authentication", usage: AuthenticationKey, key_data: Some(CompressedEcKeyData(CompressedEcKeyData { curve: "Ed25519", data: [223, 135, 255, 218, 239, 245, 37, 81, 59, 158, 15, 245, 49, 43, 5, 11, 144, 11, 135, 212, 103, 83, 147, 11, 242, 61, 164, 166, 221, 93, 8, 232] })) }, PublicKey { id: "my-key-assertionMethod", usage: IssuingKey, key_data: Some(CompressedEcKeyData(CompressedEcKeyData { curve: "Ed25519", data: [203, 185, 241, 78, 94, 120, 33, 5, 154, 58, 243, 185, 48, 198, 158, 72, 86, 153, 209, 84, 105, 95, 89, 244, 30, 154, 229, 231, 35, 95, 161, 24] })) }, PublicKey { id: "master0", usage: MasterKey, key_data: Some(CompressedEcKeyData(CompressedEcKeyData { curve: "secp256k1", data: [2, 5, 143, 115, 149, 14, 232, 30, 33, 158, 195, 147, 156, 187, 58, 41, 52, 245, 181, 6, 150, 148, 199, 65, 145, 126, 96, 136, 68, 24, 166, 18, 211] })) }], services: [], context: [] }) })) }) }

Error stack:
invalid did operation was processed

Caused by:
0: error occurred in CreateOperation
1: invalid public key found in CreateOperation
2: unable to parse key data to a public key for id my-key-authentication
3: unsupported curve Ed25519
```