### PR TITLE
Detach thread when oura timeout receiving event

### DIFF
--- a/prism-node/src/http/model.rs
+++ b/prism-node/src/http/model.rs
@@ -65,12 +65,14 @@ pub mod api {
                 .public_keys
                 .iter()
                 .filter(|k| {
-                    let usage = k.usage();
-                    usage == KeyUsage::AuthenticationKey
-                        || usage == KeyUsage::IssuingKey
-                        || usage == KeyUsage::KeyAgreementKey
-                        || usage == KeyUsage::CapabilityInvocationKey
-                        || usage == KeyUsage::CapabilityDelegationKey
+                    const W3C_KEY_TYPES: [KeyUsage; 5] = [
+                        KeyUsage::AuthenticationKey,
+                        KeyUsage::IssuingKey,
+                        KeyUsage::KeyAgreementKey,
+                        KeyUsage::CapabilityInvocationKey,
+                        KeyUsage::CapabilityDelegationKey,
+                    ];
+                    W3C_KEY_TYPES.iter().any(|usage| usage == &k.usage())
                 })
                 .flat_map(|k| transform_key_jwk(did, k))
                 .collect();


### PR DESCRIPTION
There is a pipeline restart mechanism when something is wrong with the pipeline. If the NeoPRISM is running long enough and it has disconnected from Cardano, the `rx` will not receive any event and the thread will hangs. Ideally, the restart should be initiated from oura or re-connect mechanism should be abstracted away. This is a work around to get pipeline to restart by detaching oura thread.